### PR TITLE
refactor: consolidate timestamp parsing into shared utility

### DIFF
--- a/internal/collections/models.go
+++ b/internal/collections/models.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/maniac-en/req/internal/crud"
 	"github.com/maniac-en/req/internal/database"
-	"github.com/maniac-en/req/internal/log"
 )
 
 type CollectionEntity struct {
@@ -21,21 +20,11 @@ func (c CollectionEntity) GetName() string {
 }
 
 func (c CollectionEntity) GetCreatedAt() time.Time {
-	parsed, err := time.Parse(time.RFC3339, c.CreatedAt)
-	if err != nil {
-		log.Debug("failed to parse created_at timestamp", "timestamp", c.CreatedAt, "error", err)
-		return time.Time{}
-	}
-	return parsed
+	return crud.ParseTimestamp(c.CreatedAt)
 }
 
 func (c CollectionEntity) GetUpdatedAt() time.Time {
-	parsed, err := time.Parse(time.RFC3339, c.UpdatedAt)
-	if err != nil {
-		log.Debug("failed to parse updated_at timestamp", "timestamp", c.UpdatedAt, "error", err)
-		return time.Time{}
-	}
-	return parsed
+	return crud.ParseTimestamp(c.UpdatedAt)
 }
 
 type CollectionsManager struct {

--- a/internal/crud/utils.go
+++ b/internal/crud/utils.go
@@ -3,6 +3,7 @@ package crud
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/maniac-en/req/internal/log"
 )
@@ -26,4 +27,14 @@ func ValidateID(id int64) error {
 		return fmt.Errorf("ID must be positive")
 	}
 	return nil
+}
+
+// ParseTimestamp safely parses RFC3339 timestamp strings from database
+func ParseTimestamp(timestamp string) time.Time {
+	parsed, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		log.Debug("failed to parse timestamp", "timestamp", timestamp, "error", err)
+		return time.Time{}
+	}
+	return parsed
 }

--- a/internal/endpoints/models.go
+++ b/internal/endpoints/models.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/maniac-en/req/internal/crud"
 	"github.com/maniac-en/req/internal/database"
-	"github.com/maniac-en/req/internal/log"
 )
 
 type EndpointEntity struct {
@@ -21,21 +20,11 @@ func (c EndpointEntity) GetName() string {
 }
 
 func (c EndpointEntity) GetCreatedAt() time.Time {
-	parsed, err := time.Parse(time.RFC3339, c.CreatedAt)
-	if err != nil {
-		log.Debug("failed to parse created_at timestamp", "timestamp", c.CreatedAt, "error", err)
-		return time.Time{}
-	}
-	return parsed
+	return crud.ParseTimestamp(c.CreatedAt)
 }
 
 func (c EndpointEntity) GetUpdatedAt() time.Time {
-	parsed, err := time.Parse(time.RFC3339, c.UpdatedAt)
-	if err != nil {
-		log.Debug("failed to parse updated_at timestamp", "timestamp", c.UpdatedAt, "error", err)
-		return time.Time{}
-	}
-	return parsed
+	return crud.ParseTimestamp(c.UpdatedAt)
 }
 
 type EndpointsManager struct {

--- a/internal/history/models.go
+++ b/internal/history/models.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/maniac-en/req/internal/crud"
 	"github.com/maniac-en/req/internal/database"
-	"github.com/maniac-en/req/internal/log"
 )
 
 type HistoryManager struct {
@@ -26,12 +25,7 @@ func (h HistoryEntity) GetName() string {
 }
 
 func (h HistoryEntity) GetCreatedAt() time.Time {
-	t, err := time.Parse(time.RFC3339, h.ExecutedAt)
-	if err != nil {
-		log.Error("failed to parse executed_at timestamp", "executed_at", h.ExecutedAt, "error", err)
-		return time.Time{}
-	}
-	return t
+	return crud.ParseTimestamp(h.ExecutedAt)
 }
 
 // GetUpdatedAt returns creation time since history entries are immutable


### PR DESCRIPTION
- Added ParseTimestamp utility to crud package
- Replaced duplicated timestamp parsing in collections, endpoints, history