### PR TITLE
Release prep: v0.1.0-alpha.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,16 +83,6 @@ jobs:
             
             **Usage:** Run `req` in your terminal
             
-            **Breaking Changes:**
-            Database schema has been updated. Please remove your existing database:
-            ```bash
-            # Linux/macOS
-            rm ~/.cache/req/app.db
-            
-            # Windows
-            del %LOCALAPPDATA%\req\app.db
-            ```
-            
             **Note:** This is early development software. Core HTTP execution features are still in progress.
             
             Full changelog: https://github.com/maniac-en/req/commits/${{ env.VERSION }}

--- a/internal/tui/app/context.go
+++ b/internal/tui/app/context.go
@@ -13,6 +13,7 @@ type Context struct {
 	HTTP             *http.HTTPManager
 	History          *history.HistoryManager
 	DummyDataCreated bool
+	Version          string
 }
 
 func NewContext(
@@ -20,6 +21,7 @@ func NewContext(
 	endpoints *endpoints.EndpointsManager,
 	httpManager *http.HTTPManager,
 	history *history.HistoryManager,
+	version string,
 ) *Context {
 	return &Context{
 		Collections:      collections,
@@ -27,6 +29,7 @@ func NewContext(
 		HTTP:             httpManager,
 		History:          history,
 		DummyDataCreated: false,
+		Version:          version,
 	}
 }
 

--- a/internal/tui/app/model.go
+++ b/internal/tui/app/model.go
@@ -176,7 +176,7 @@ func (a AppModel) Header() string {
 func (a AppModel) Footer() string {
 	name := styles.ApplyGradientToFooter("REQ")
 	footerText := styles.FooterSegmentStyle.Render(a.Views[a.focusedView].GetFooterSegment())
-	version := styles.FooterVersionStyle.Width(a.width - lipgloss.Width(name) - lipgloss.Width(footerText)).Render("v0.1.0-alpha.2")
+	version := styles.FooterVersionStyle.Width(a.width - lipgloss.Width(name) - lipgloss.Width(footerText)).Render(a.ctx.Version)
 	return lipgloss.JoinHorizontal(lipgloss.Left, name, footerText, version)
 }
 

--- a/main.go
+++ b/main.go
@@ -141,6 +141,7 @@ func main() {
 		endpointsManager,
 		httpManager,
 		historyManager,
+		Version,
 	)
 
 	// populate dummy data for demo


### PR DESCRIPTION
## Summary
Prepares the codebase for releasing v0.1.0-alpha.2

## Changes
- Remove breaking changes section from release workflow (no DB schema changes in this release)
- Fix hardcoded version in TUI footer to use injected version from build process
- Update Context to pass version from main.go to TUI components

## Test Plan
- Build process works correctly
- TUI shows proper version in footer
- Release workflow generates clean release notes without breaking changes section

Once merged, ready to tag v0.1.0-alpha.2 on main branch.