### PR TITLE
Fix version detection for go install

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/maniac-en/req/internal/backend/collections"
@@ -37,6 +38,18 @@ var (
 )
 
 var Version = "dev"
+
+func getVersion() string {
+	// Try to get version from build info (works with go install)
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if info.Main.Version != "" && info.Main.Version != "(devel)" {
+			return info.Main.Version
+		}
+	}
+	
+	// Fall back to injected version (release builds)
+	return Version
+}
 
 func initPaths() error {
 	// setup paths using OS-appropriate cache directory
@@ -141,7 +154,7 @@ func main() {
 		endpointsManager,
 		httpManager,
 		historyManager,
-		Version,
+		getVersion(),
 	)
 
 	// populate dummy data for demo


### PR DESCRIPTION
## Summary
Fixes TUI footer showing 'dev' when installed via `go install github.com/maniac-en/req@vX.Y.Z`

## Problem
- v0.1.0-alpha.2 shows 'dev' in footer when installed via go install
- Version injection only works for GitHub release binaries (via ldflags)
- go install builds from source without ldflags

## Solution
- Add `debug.ReadBuildInfo()` to detect module version at runtime
- Works automatically when go install uses specific version tags
- Falls back to injected version for release builds

## Test Plan
- Local development: shows 'dev' 
- Release builds: shows injected version via ldflags
- go install @vX.Y.Z: shows correct version from build info

Resolves version display issue for go install users.